### PR TITLE
add flag to allow user set dynamic concurrency instead of using hardcoded number

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,10 +116,10 @@ func main() {
 			Name:  "env-file",
 			Usage: "source env file",
 		},
-		cli.StringFlag{
+		cli.IntFlag{
 			Name:  "max-concurrency",
 			Usage: "customize number concurrent files to process",
-			Value: "100",
+			Value: 100,
 			EnvVar: "PLUGIN_MAX_CONCURRENCY",
 
 		},
@@ -152,7 +152,7 @@ func run(c *cli.Context) error {
 		Redirects:              c.Generic("redirects").(*MapFlag).Get(),
 		CloudFrontDistribution: c.String("cloudfront-distribution"),
 		DryRun:                 c.Bool("dry-run"),
-		MaxConcurrency:         c.String("max-concurrency"),
+		MaxConcurrency:         c.Int("max-concurrency"),
 	}
 
 	return plugin.Exec()

--- a/main.go
+++ b/main.go
@@ -116,6 +116,13 @@ func main() {
 			Name:  "env-file",
 			Usage: "source env file",
 		},
+		cli.StringFlag{
+			Name:  "max-concurrency",
+			Usage: "customize number concurrent files to process",
+			Value: "100",
+			EnvVar: "PLUGIN_MAX_CONCURRENCY",
+
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -145,6 +152,7 @@ func run(c *cli.Context) error {
 		Redirects:              c.Generic("redirects").(*MapFlag).Get(),
 		CloudFrontDistribution: c.String("cloudfront-distribution"),
 		DryRun:                 c.Bool("dry-run"),
+		MaxConcurrency:         c.String("max-concurrency"),
 	}
 
 	return plugin.Exec()

--- a/plugin.go
+++ b/plugin.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"strconv"
 )
 
 type Plugin struct {
@@ -29,7 +28,7 @@ type Plugin struct {
 	PathStyle              bool
 	client                 AWS
 	jobs                   []job
-	MaxConcurrency         string
+	MaxConcurrency         int
 }
 
 type job struct {
@@ -156,13 +155,7 @@ func (p *Plugin) createInvalidateJob() {
 
 func (p *Plugin) runJobs() {
 	client := p.client
-	maxConcurrency, err := strconv.Atoi(p.MaxConcurrency)
-	if err != nil {
-		fmt.Printf("ERROR: invalid input for max-concurrency")
-		os.Exit(1)
-	}
-
-	jobChan := make(chan struct{}, maxConcurrency)
+	jobChan := make(chan struct{}, p.MaxConcurrency)
 	results := make(chan *result, len(p.jobs))
 	var invalidateJob *job
 

--- a/plugin.go
+++ b/plugin.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"strconv"
 )
 
 type Plugin struct {
@@ -28,9 +29,8 @@ type Plugin struct {
 	PathStyle              bool
 	client                 AWS
 	jobs                   []job
+	MaxConcurrency         string
 }
-
-const maxConcurrent = 100
 
 type job struct {
 	local  string
@@ -156,7 +156,13 @@ func (p *Plugin) createInvalidateJob() {
 
 func (p *Plugin) runJobs() {
 	client := p.client
-	jobChan := make(chan struct{}, maxConcurrent)
+	maxConcurrency, err := strconv.Atoi(p.MaxConcurrency)
+	if err != nil {
+		fmt.Printf("ERROR: invalid input for max-concurrency")
+		os.Exit(1)
+	}
+
+	jobChan := make(chan struct{}, maxConcurrency)
 	results := make(chan *result, len(p.jobs))
 	var invalidateJob *job
 


### PR DESCRIPTION
We would like to add a feature that allow user to customize number of concurrency. Status quo remains 100 if user does not specify.

Why do we want this?

Currently, the concurrent number of files being processes is a hard-coded `100`. This would fail at times when there are not enough resources available on the machine.

At Skyscanner, we run the `drone-s3-sync` in a docker process that is deployed to a shared AWS EC2 cluster. This docker container gets deployed to a different machine(machine resources shared with other projects as well) every time build is triggered. Sometime when it got deployed to a busy machine with little resources left, and if it's a big project with thousands of files to sync with S3 bucket(3000 files in our case), the entire process would error out with `too many open files`. 

In practice this is causing almost 50% of our deployment processes fail due to this error. 

I'm also able to duplicate this problem on my local machine as well, see screenshots below:

<img width="1143" alt="drone-s3-sync-error-cloud" src="https://user-images.githubusercontent.com/6464677/44120826-84fd38a2-9fd2-11e8-8185-98f8c5919902.png">

<img width="1438" alt="drone-s3-sync-error-local" src="https://user-images.githubusercontent.com/6464677/44120839-8ad0c05a-9fd2-11e8-9b95-4926d86efdc3.png">

With this change, users can set a dynamic concurrency number, allowing us to set a relative conservative concurrency(such as 20 or even 10). 

Note this change DOES NOT change status quo behavior, if user does not have resource limits and does not specify concurrency, it will still use the default `100` value.. 