### PR TITLE
added support for verbose variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,6 +112,11 @@ func main() {
 			Usage:  "dry run disables api calls",
 			EnvVar: "DRY_RUN,PLUGIN_DRY_RUN",
 		},
+		cli.BoolFlag{
+			Name:   "verbose",
+			Usage:  "make plugin return verbose log from the process",
+			EnvVar: "VERBOSE, PLUGIN_VERBOSE",
+		},
 		cli.StringFlag{
 			Name:  "env-file",
 			Usage: "source env file",
@@ -144,6 +149,7 @@ func run(c *cli.Context) error {
 		Source:                 c.String("source"),
 		Target:                 c.String("target"),
 		Delete:                 c.Bool("delete"),
+		Verbose:                 c.Bool("verbose"),
 		Access:                 c.Generic("access").(*StringMapFlag).Get(),
 		CacheControl:           c.Generic("cache-control").(*StringMapFlag).Get(),
 		ContentType:            c.Generic("content-type").(*StringMapFlag).Get(),

--- a/plugin.go
+++ b/plugin.go
@@ -199,7 +199,7 @@ func (p *Plugin) runJobs() {
 }
 
 func debug(format string, args ...interface{}) {
-	if os.Getenv("DEBUG") != "" || os.Getenv("DEBUG") != "" {
+	if os.Getenv("DEBUG") != "" || os.Getenv("VERBOSE") != "" {
 		fmt.Printf(format+"\n", args...)
 	} else {
 		fmt.Printf(".")

--- a/plugin.go
+++ b/plugin.go
@@ -17,6 +17,7 @@ type Plugin struct {
 	Source                 string
 	Target                 string
 	Delete                 bool
+	Verbose                bool
 	Access                 map[string]string
 	CacheControl           map[string]string
 	ContentType            map[string]string
@@ -198,7 +199,7 @@ func (p *Plugin) runJobs() {
 }
 
 func debug(format string, args ...interface{}) {
-	if os.Getenv("DEBUG") != "" {
+	if os.Getenv("DEBUG") != "" || os.Getenv("DEBUG") != "" {
 		fmt.Printf(format+"\n", args...)
 	} else {
 		fmt.Printf(".")


### PR DESCRIPTION
the plugin currently supports verbosity in a "debug" mode.

this is misleading due to the fact that debug is not the same as verbose.

I added support for verbose logging by having a verbose variable in the plugin.

(I didn't know where do you document your variables so if I'm missing anything, please let me know)

re-openned from #44 due to wrong pull reference in drone