### PR TITLE
Add option to empty bucket before sync

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -384,3 +384,26 @@ func (a *AWS) Invalidate(invalidatePath string) error {
 	})
 	return err
 }
+
+func (a *AWS) EmptyBucket() error {
+	p := a.plugin
+	debug("Emptying bucket \"%s\"", p.Bucket)
+
+	if a.plugin.DryRun {
+		return nil
+	}
+
+	objects, err := a.List("")
+	if err != nil {
+		return err
+	}
+
+	for _, object := range objects {
+		err = a.Delete(object)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -67,6 +67,11 @@ func main() {
 			Usage:  "delete locally removed files from the target",
 			EnvVar: "PLUGIN_DELETE",
 		},
+		cli.BoolFlag{
+			Name:   "empty-bucket",
+			Usage:  "delete all files from the target bucket",
+			EnvVar: "PLUGIN_EMPTY_BUCKET",
+		},
 		cli.GenericFlag{
 			Name:   "access",
 			Usage:  "access control settings",
@@ -144,6 +149,7 @@ func run(c *cli.Context) error {
 		Source:                 c.String("source"),
 		Target:                 c.String("target"),
 		Delete:                 c.Bool("delete"),
+		EmptyBucket:            c.Bool("empty-bucket"),
 		Access:                 c.Generic("access").(*StringMapFlag).Get(),
 		CacheControl:           c.Generic("cache-control").(*StringMapFlag).Get(),
 		ContentType:            c.Generic("content-type").(*StringMapFlag).Get(),

--- a/plugin.go
+++ b/plugin.go
@@ -17,6 +17,7 @@ type Plugin struct {
 	Source                 string
 	Target                 string
 	Delete                 bool
+	EmptyBucket            bool
 	Access                 map[string]string
 	CacheControl           map[string]string
 	ContentType            map[string]string
@@ -155,7 +156,17 @@ func (p *Plugin) runJobs() {
 	results := make(chan *result, len(p.jobs))
 	var invalidateJob *job
 
+	if(p.EmptyBucket) {
+		fmt.Printf("Emptying bucket \"%s before synchronizing \"\n", p.Bucket)
+		err := client.EmptyBucket()
+		if err != nil {
+			fmt.Printf("ERROR: failed to empty bucket: %+v\n", err)
+			os.Exit(1)
+		}
+	}
+
 	fmt.Printf("Synchronizing with bucket \"%s\"\n", p.Bucket)
+
 	for _, j := range p.jobs {
 		jobChan <- struct{}{}
 		go func(j job) {


### PR DESCRIPTION
Add a functionality to empty the target bucket before sync. This can be useful for static website deployment when the last deploy should be removed.

I think there's another way to do the bucket emptying which involves [recursively deleting](https://docs.aws.amazon.com/AmazonS3/latest/userguide/empty-bucket.html  ) everything from `/`. But I haven't found any api for it in the golang aws sdk. 