### PR TITLE
fix: [CI-21342] Harden AWS SDK v2 migration for S3-compatible endpoints

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -74,10 +74,10 @@ func NewAWS(p *Plugin) AWS {
 }
 
 func normalizeEndpoint(endpoint string) string {
-	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
-		return "https://" + endpoint
+	if endpoint == "" || strings.Contains(endpoint, "://") {
+		return endpoint
 	}
-	return endpoint
+	return "https://" + endpoint
 }
 
 func (a *AWS) Upload(local, remote string) error {

--- a/aws.go
+++ b/aws.go
@@ -9,6 +9,7 @@ import (
 	"mime"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -50,9 +51,13 @@ func NewAWS(p *Plugin) AWS {
 
 	s3Opts := []func(*s3.Options){}
 	if p.Endpoint != "" {
+		endpoint := normalizeEndpoint(p.Endpoint)
 		s3Opts = append(s3Opts, func(o *s3.Options) {
-			o.BaseEndpoint = aws.String(p.Endpoint)
+			o.BaseEndpoint = aws.String(endpoint)
 			o.UsePathStyle = p.PathStyle
+			// S3-compatible services (MinIO, Spaces, B2, etc.) may not support the
+			// CRC32 checksums that SDK v2 sends by default with PutObject.
+			o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 		})
 	} else if p.PathStyle {
 		s3Opts = append(s3Opts, func(o *s3.Options) {
@@ -66,6 +71,13 @@ func NewAWS(p *Plugin) AWS {
 	l := make([]string, 1)
 
 	return AWS{c, cf, r, l, p}
+}
+
+func normalizeEndpoint(endpoint string) string {
+	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		return "https://" + endpoint
+	}
+	return endpoint
 }
 
 func (a *AWS) Upload(local, remote string) error {
@@ -142,7 +154,7 @@ func (a *AWS) Upload(local, remote string) error {
 		var apiErr smithy.APIError
 		isNotFound := false
 		if ok := errors.As(err, &apiErr); ok {
-			if apiErr.ErrorCode() == "404" || apiErr.ErrorCode() == "NotFound" {
+			if apiErr.ErrorCode() == "404" || apiErr.ErrorCode() == "NotFound" || apiErr.ErrorCode() == "NoSuchKey" {
 				isNotFound = true
 			}
 		}
@@ -208,7 +220,7 @@ func (a *AWS) Upload(local, remote string) error {
 	_, _ = io.Copy(hash, file)
 	sum := fmt.Sprintf("\"%x\"", hash.Sum(nil))
 
-	if sum == *head.ETag {
+	if head.ETag != nil && sum == *head.ETag {
 		shouldCopy := false
 
 		if head.ContentType == nil && contentType != "" {


### PR DESCRIPTION
## Summary

Fixes critical behavioral differences between AWS SDK Go v1 and v2 that can break S3-compatible service integrations (MinIO, DigitalOcean Spaces, Backblaze B2, etc.):

- **Endpoint scheme normalization**: Added `normalizeEndpoint()` to prepend `https://` when users provide bare hostnames
- **CRC32 checksum compatibility**: Disabled via `RequestChecksumCalculationWhenRequired` for custom endpoints only
- **NoSuchKey error code**: Added `NoSuchKey` to HeadObject error code checks
- **ETag nil guard**: Added nil check before dereference

Note: This PR also includes the initial AWS SDK v1 to v2 migration commit.

## Test plan

- [ ] Sync to AWS S3 with default endpoint
- [ ] Sync to MinIO/Spaces with custom endpoint
- [ ] CloudFront invalidation after sync

Made with [Cursor](https://cursor.com)